### PR TITLE
Bug 1390320 - Allow Dataset api consumers to control the amount of parallelism used

### DIFF
--- a/src/test/scala/com/mozilla/telemetry/utils/ObjectSummaryTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/utils/ObjectSummaryTest.scala
@@ -17,4 +17,28 @@ class ObjectSummaryTest extends FlatSpec with Matchers {
     groups.size should be (Math.ceil(totalBytes.toFloat/(threshold - 1)).toInt)
     groups.flatMap(x => x).map(_.size).sum should be (totalBytes)
   }
+
+  "ObjectSummarys" can "be grouped into a specific number of groups" in {
+    val testSummaries = List(5, 1, 2, 3, 9, 8, 7, 1, 12, 8).map(x => ObjectSummary(x.toString, x))
+    val groups = ObjectSummary.equallySizedGroups(testSummaries.toIterator, 5)
+    val expectedGroups = List(
+      List(1, 9),
+      List(3, 8),
+      List(5, 7),
+      List(12),
+      List(1, 2, 8)
+    ).map(g => g.map(x => ObjectSummary(x.toString, x)))
+    // This is overly strict, but it's unclear to me the best way to guarantee "as close to equal as possible"
+    // short of hardcoding an example check.
+    groups should be(expectedGroups)
+  }
+
+  "ObjectSummarys" should "respect the threshold parameter over group count when a number of groups is requested" in {
+    val testSummaries = List(5, 5, 5, 5, 5).map(x => ObjectSummary(x.toString, x))
+    val groups = ObjectSummary.equallySizedGroups(testSummaries.toIterator, 2, 11)
+    groups.size should be(3)
+    groups.flatten.map(_.size).sum should be(25)
+    groups.map(l => l.map(_.size).sum).max should be(10)
+  }
+
 }


### PR DESCRIPTION
As it is it often forces a potentially very expensive shuffle in order to increase the parallelism. This was causing performance issues in a zeppelin notebook I was using for bug 1381641, where I'd get around 3 partitions and want to expand them to a much larger size.

It would probably be simpler without the threshold checking, but given it's current value, it seems like it might be intended to prevent something further down the line from hitting some signed integer overflow later, I wasn't sure.

I've made it opt-in, although it seems likely to be a better default than the current (if you ask me).