### PR TITLE
Bug 1462773: Add Processes parser

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,8 @@ libraryDependencies ++= Seq(
   "com.storm-enroute" %% "scalameter" % "0.8.2" % "bench",
   "com.github.seratch" %% "awscala" % "0.5.+",
   "com.amazonaws" % "aws-java-sdk" % "1.11.83",
-  "com.google.protobuf" % "protobuf-java" % "2.5.0"
+  "com.google.protobuf" % "protobuf-java" % "2.5.0",
+  "org.yaml" % "snakeyaml" % "1.21"
 )
 
 /*

--- a/src/main/scala/com/mozilla/telemetry/pings/main/Processes.scala
+++ b/src/main/scala/com/mozilla/telemetry/pings/main/Processes.scala
@@ -13,9 +13,11 @@ class ProcessesClass {
   protected val getURL: (String, String) => scala.io.Source = Source.fromURL
 
   protected lazy val parsedProcesses: Map[String, Seq[Process]] = {
-    val uris = Map("release" -> "https://hg.mozilla.org/releases/mozilla-release/raw-file/tip/toolkit/components/telemetry/Processes.yaml",
-      "beta" -> "https://hg.mozilla.org/releases/mozilla-beta/raw-file/tip/toolkit/components/telemetry/Processes.yaml",
-      "nightly" -> "https://hg.mozilla.org/mozilla-central/raw-file/tip/toolkit/components/telemetry/Processes.yaml")
+    val raw = (branch: String) => s"""https://hg.mozilla.org/$branch/raw-file/tip/toolkit/components/telemetry/Processes.yaml"""
+    val uris = Map(
+      "release" -> raw("releases/mozilla-release"),
+      "beta" -> raw("releases/mozilla-beta"),
+      "nightly" -> raw("mozilla-central"))
     val sources = uris.map { case (key, value) => key -> getURL(value, "UTF8") }
     sources.map { case (key, source) => {
       val parsed = (new Yaml().load(source.mkString)).asInstanceOf[util.LinkedHashMap[String, util.LinkedHashMap[String, String]]]

--- a/src/main/scala/com/mozilla/telemetry/pings/main/Processes.scala
+++ b/src/main/scala/com/mozilla/telemetry/pings/main/Processes.scala
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package com.mozilla.telemetry.pings.main
+
+import scala.io.Source
+import org.yaml.snakeyaml.Yaml
+import collection.JavaConversions._
+import java.util
+
+class ProcessesClass {
+  protected case class Process(name: String, geckoEnum: Option[String], description: Option[String])
+  protected val getURL: (String, String) => scala.io.Source = Source.fromURL
+
+  protected lazy val parsedProcesses: Map[String, Seq[Process]] = {
+    val uris = Map("release" -> "https://hg.mozilla.org/releases/mozilla-release/raw-file/tip/toolkit/components/telemetry/Processes.yaml",
+      "beta" -> "https://hg.mozilla.org/releases/mozilla-beta/raw-file/tip/toolkit/components/telemetry/Processes.yaml",
+      "nightly" -> "https://hg.mozilla.org/mozilla-central/raw-file/tip/toolkit/components/telemetry/Processes.yaml")
+    val sources = uris.map { case (key, value) => key -> getURL(value, "UTF8") }
+    sources.map { case (key, source) => {
+      val parsed = (new Yaml().load(source.mkString)).asInstanceOf[util.LinkedHashMap[String, util.LinkedHashMap[String, String]]]
+      val processes = parsed
+        .map {case (name, paramsJavaMap) => {
+          val params = mapAsScalaMap(paramsJavaMap)
+          Process(name, params.get("gecko_enum"), params.get("description"))
+        }}
+        .toSeq
+      key -> processes
+    }
+    }
+  }
+
+  lazy val names: Seq[String] =
+    parsedProcesses.flatMap { case (_, processes) =>
+      processes.map(_.name)
+    }.toSeq.distinct
+}
+
+object Processes extends ProcessesClass

--- a/src/test/scala/com/mozilla/telemetry/pings/main/ProcessesTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/pings/main/ProcessesTest.scala
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+package com.mozilla.telemetry.pings.main
+
+import org.scalatest.{FlatSpec, Matchers}
+import scala.io.Source
+
+class ProcessesTest extends FlatSpec with Matchers {
+  val fixture = {
+    new {
+      val processClass = new ProcessesClass {
+        override protected val getURL = (a: String, b: String) => Source.fromString(
+          """
+            |hello:
+            |  gecko_enum: GeckoProcessType_Default
+            |  description: This is a test process called 'hello'
+            |world:
+            |  description: This is a test process called 'world' without a gecko_enum field
+          """.stripMargin)
+      }
+    }
+  }
+
+  "Process names" should "be returned as a seq" in {
+    fixture.processClass.names should be (Seq("hello", "world"))
+  }
+}


### PR DESCRIPTION
Adding a simple parser for [`Processes.yaml`](https://hg.mozilla.org/releases/mozilla-release/raw-file/tip/toolkit/components/telemetry/Processes.yaml) here so we can stop trying to keep lists up to date in both t-b-v and telemetry-streaming. When we switch over to using the probe scraper service as described in the bug, we should be able to swap out the backend while keeping the (very simple) interface consistent.

Don't hesitate to go to town on this -- I'd love any and all feedback on improving style, etc