### PR TITLE
Scalastyle & compiler config updates

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -52,6 +52,13 @@ lazy val root =
 )
 publishArtifact in Benchmark := false
 
+scalacOptions ++= Seq(
+  "-feature",
+  "-Ywarn-unused",
+  "-Ywarn-unused-import",
+  "-Xfatal-warnings"
+)
+
 publishMavenStyle := true
 
 publishTo := {

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -1,11 +1,6 @@
 <scalastyle>
     <name>Scalastyle standard configuration</name>
     <check level="error" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
-    <check level="error" class="org.scalastyle.file.FileLengthChecker" enabled="true">
-        <parameters>
-            <parameter name="maxFileLength"><![CDATA[800]]></parameter>
-        </parameters>
-    </check>
     <check level="error" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">
         <parameters>
             <parameter name="header"><![CDATA[/* This Source Code Form is subject to the terms of the Mozilla Public
@@ -48,15 +43,9 @@
             <parameter name="maxParameters"><![CDATA[8]]></parameter>
         </parameters>
     </check>
-    <check level="error" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="false">
-        <parameters>
-            <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter>
-        </parameters>
-    </check>
     <check level="error" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker" enabled="true"></check>
-    <check level="error" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
-    <check level="error" class="org.scalastyle.scalariform.NullChecker" enabled="false"></check>
+    <check customId="return" level="error" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.NoCloneChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
@@ -71,22 +60,12 @@
             <parameter name="maxTypes"><![CDATA[30]]></parameter>
         </parameters>
     </check>
-    <check level="error" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="false">
-        <parameters>
-            <parameter name="maximum"><![CDATA[10]]></parameter>
-        </parameters>
-    </check>
     <check level="error" class="org.scalastyle.scalariform.UppercaseLChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.scalariform.IfBraceChecker" enabled="true">
         <parameters>
             <parameter name="singleLineAllowed"><![CDATA[true]]></parameter>
             <parameter name="doubleLineAllowed"><![CDATA[false]]></parameter>
-        </parameters>
-    </check>
-    <check customId="methodLength" level="error" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
-        <parameters>
-            <parameter name="maxLength"><![CDATA[100]]></parameter>
         </parameters>
     </check>
     <check customId="methodName" level="error" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
@@ -101,5 +80,48 @@
     </check>
     <check level="error" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="true"></check>
     <check level="error" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
+
+    <!--=============================================================================================================-->
+    <!--                                              temporary rules                                                -->
+    <!--=============================================================================================================-->
+    <check level="warn" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
+        <parameters>
+            <parameter name="illegalImports"><![CDATA[org.joda._]]></parameter>
+        </parameters>
+    </check>
+
+    <!--=============================================================================================================-->
+    <!--                                     rules we don't want to enforce yet                                      -->
+    <!--=============================================================================================================-->
+    <check level="warning" class="org.scalastyle.scalariform.UnderscoreImportChecker" enabled="false">
+        <parameters>
+            <parameter name="ignoreRegex">collection\.JavaConverters\._|scala\.concurrent\.duration\._|spark\.implicits\._</parameter>
+        </parameters>
+    </check>
+
+    <!--=============================================================================================================-->
+    <!--                                       rules we don't want to enforce                                        -->
+    <!--=============================================================================================================-->
+    <check level="error" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="false">
+        <parameters>
+            <parameter name="maximum"><![CDATA[10]]></parameter>
+        </parameters>
+    </check>
+    <check level="error" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="false">
+        <parameters>
+            <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter>
+        </parameters>
+    </check>
     <check level="error" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
+    <check level="error" class="org.scalastyle.scalariform.NullChecker" enabled="false"></check>
+    <check level="error" class="org.scalastyle.file.FileLengthChecker" enabled="false">
+        <parameters>
+            <parameter name="maxFileLength"><![CDATA[800]]></parameter>
+        </parameters>
+    </check>
+    <check level="error" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="false">
+        <parameters>
+            <parameter name="maxLength"><![CDATA[100]]></parameter>
+        </parameters>
+    </check>
 </scalastyle>

--- a/src/main/scala/com/mozilla/telemetry/heka/Dataset.scala
+++ b/src/main/scala/com/mozilla/telemetry/heka/Dataset.scala
@@ -10,6 +10,7 @@ import org.json4s._
 import org.json4s.jackson.JsonMethods.parse
 
 import scala.io.Source
+import scala.language.implicitConversions
 
 private case class Schema(dimensions: List[Dimension])
 private case class Dimension(fieldName: String)

--- a/src/main/scala/com/mozilla/telemetry/heka/package.scala
+++ b/src/main/scala/com/mozilla/telemetry/heka/package.scala
@@ -4,9 +4,11 @@
 package com.mozilla.telemetry
 
 import com.google.protobuf.ByteString
+import org.json4s.JsonDSL._
 import org.json4s._
 import org.json4s.jackson.JsonMethods._
-import org.json4s.JsonDSL._
+
+import scala.language.implicitConversions
 import scala.util.Try
 
 package object heka {

--- a/src/test/scala/com/mozilla/telemetry/heka/FileTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/heka/FileTest.scala
@@ -5,7 +5,6 @@ package com.mozilla.telemetry.heka
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, InputStream}
 
-import org.scalatest.Assertions.{assertThrows}
 import org.scalatest.{FlatSpec, Matchers}
 import org.xerial.snappy.Snappy
 

--- a/src/test/scala/com/mozilla/telemetry/pings/main/ProcessesTest.scala
+++ b/src/test/scala/com/mozilla/telemetry/pings/main/ProcessesTest.scala
@@ -4,25 +4,22 @@
 package com.mozilla.telemetry.pings.main
 
 import org.scalatest.{FlatSpec, Matchers}
+
 import scala.io.Source
 
 class ProcessesTest extends FlatSpec with Matchers {
-  val fixture = {
-    new {
-      val processClass = new ProcessesClass {
-        override protected val getURL = (a: String, b: String) => Source.fromString(
-          """
-            |hello:
-            |  gecko_enum: GeckoProcessType_Default
-            |  description: This is a test process called 'hello'
-            |world:
-            |  description: This is a test process called 'world' without a gecko_enum field
-          """.stripMargin)
-      }
-    }
+  val processClass = new ProcessesClass {
+    override protected val getURL = (a: String, b: String) => Source.fromString(
+      """
+        |hello:
+        |  gecko_enum: GeckoProcessType_Default
+        |  description: This is a test process called 'hello'
+        |world:
+        |  description: This is a test process called 'world' without a gecko_enum field
+      """.stripMargin)
   }
 
   "Process names" should "be returned as a seq" in {
-    fixture.processClass.names should be (Seq("hello", "world"))
+    processClass.names should be(Seq("hello", "world"))
   }
 }


### PR DESCRIPTION
In this PR:
* scalastyle config is cleaned and nicely commented
* sbt version is bumped
* compiler is configured to:
  * warn on unused imports and declarations
  * fail the build on any warnings

Scalastyle-related commits should be squashed before merging.