### PR TITLE
Exclude scalameter from published pom

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,6 +69,10 @@ publishTo := {
     Some("releases"  at localMaven + "releases")
 }
 
+// Make sure we don't include benchmark dependencies in the pom
+// https://github.com/sbt/sbt/issues/1380#issuecomment-388057539
+makePomConfiguration := makePomConfiguration.value.withConfigurations(Configurations.defaultMavenConfigurations)
+
 pomExtra := (
   <url>https://github.com/mozilla/moztelemetry</url>
     <licenses>


### PR DESCRIPTION
Follow-up to https://github.com/mozilla/moztelemetry/pull/23
as it turns out that `publishArtifact in Benchmark := false`
was not sufficient and t-b-v is still pulling in scalameter
transitively.